### PR TITLE
Add LEGO Spike tutorial README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# LegoSpike
+# Lego Spike Robot Tutorial
+
+This repository provides a comprehensive tutorial for building and programming a LEGO Spike robot from scratch. It is intended for beginners who want to get started with the LEGO Spike Prime platform.
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Gathering the Required Hardware](#gathering-the-required-hardware)
+3. [Setting Up the Software](#setting-up-the-software)
+4. [Building Your First Robot](#building-your-first-robot)
+5. [Programming Basics](#programming-basics)
+6. [Next Steps](#next-steps)
+
+## Introduction
+
+LEGO Spike Prime is a flexible robotics platform aimed at helping students learn the basics of robotics and programming. This tutorial walks you through the process of setting up your kit, building a simple robot, and writing your first program.
+
+## Gathering the Required Hardware
+
+Make sure you have the LEGO Spike Prime set, which includes motors, sensors, and the programmable hub. You will also need a computer or tablet with the Spike app installed.
+
+## Setting Up the Software
+
+1. Download and install the LEGO Education Spike app from the official website.
+2. Launch the app and update the hub firmware if prompted.
+3. Familiarize yourself with the interface by exploring the example projects.
+
+## Building Your First Robot
+
+Follow the instructions provided in the kit to assemble a basic drive robot. The build usually involves attaching two motors for the wheels and connecting a sensor to the front of the robot.
+
+## Programming Basics
+
+1. Open the Spike app and create a new project.
+2. Connect your hub via USB or Bluetooth.
+3. Use the block-based interface to program simple movements, such as driving forward, turning, and stopping based on sensor input.
+4. Download the code to the hub and test your robot.
+
+## Next Steps
+
+Once you are comfortable with the basics, experiment with more complex builds and programs. Explore using additional sensors or writing code in Python for greater flexibility.
+


### PR DESCRIPTION
## Summary
- rewrite README with a starter tutorial for LEGO Spike

## Testing
- `cat README.md`

------
https://chatgpt.com/codex/tasks/task_e_685388c0b2e883309526e9102eb2a922